### PR TITLE
add "weak" and "inherently-weak" properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ The following properties have specified meanings, but additional may be added, a
 - `deterministic` hints that the automaton is deterministic, i.e., it has at most one initial state, and the outgoing transitions of each state have disjoint labels (note that this also applies in the presence of universal branching)
 - `complete` hints that the automaton is complete, i.e., it has at least one state, and the transition function is total
 - `unambiguous` hints that the automaton is unambiguous, i.e., for each word there is at most one accepting run of the automaton (this also applies in the presence of universal branching)
+- `weak` hints that in each strongly connected component, all transitions (or all states) belong to the same accepting sets
+- `inherently-weak` hints that the automaton does not mix accepting cycles and non-accepting cycles in the same SCC
 
 Note that even if some property implies another one (for instance `explicit-labels` implies `trans-labels`) it is recommended to specify both.
 


### PR DESCRIPTION
I would like to indicate in the property: line if an automaton is weak.

For Büchi automata, it is customary to distinguish two kinds of weakness:
- weak Büchi automata are those in which, for each SCC, either all states are accepting, or all states are non-accepting
- inherently weak automata are those whose SCCs do not mix accepting cycles with non-accepting cycles.

Of course any weak automaton is also inherently weak, and any inherently weak automaton can be converted to a weak automaton by adjusting the acceptance set.

Essentially, a weak automaton is one in which the acceptance condition could be specified in terms of SCCs (instead of transitions or states). Presented this way (please see the wording in 947375b) the "weak" property generalizes nicely to non-Büchi automata.
