### PR TITLE
generalized-Rabin syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,10 +326,10 @@ S. Krishnan, in [his ISAAC'94 paper](http://dx.doi.org/10.1007/3-540-58325-4_202
 
 Rabin acceptance has been generalized in works by [Křetínský & Esparza](http://arxiv.org/abs/1204.5057) or [Babiak et al.](http://dx.doi.org/10.1007/978-3-319-02444-8_4).  They both translate LTL formulas into generalized Rabin automata in which the acceptance condition may look like {(E₁,{F₁₁,F₁₂,F₁₃}), (E₂,{F₂₁,F₂₂})}, and where a run is accepting if there exist some i such that the run visits finitely often the set Eᵢ and infinitely often all the sets Fᵢⱼ.  Such an acceptance condition can be specified with:
 
-    acc-name: generalized-Rabin 3 2
+    acc-name: generalized-Rabin 2 3 2
     Acceptance: 7 (F0&I1&I2&I3)|(F4&I5&I6)
 
-The number of parameters `generalized-Rabin` has corresponds to the numbers of generalized Rabin pairs, and each parameters gives the number of Fᵢⱼ sets in the corresponding pair.
+The first parameter of `generalized-Rabin` gives the number of generalized pairs and the following parameters give the number of Fᵢⱼ sets in the corresponding pairs.
 
 ### Parity automata
 


### PR DESCRIPTION
Instead of

```
acc-name: generalized-Rabin 3 2
Acceptance: 7 (F0&I1&I2&I3)|(F4&I5&I6)
```

Joachim suggested we use

```
acc-name: generalized-Rabin 2 3 2     /* note the leading 2 */
Acceptance: 7 (F0&I1&I2&I3)|(F4&I5&I6)
```

Specifying the number of generalized pairs makes this closer to other acceptance names, and also helps parsing (in the same way as we give the number of atomic propositions before listing them on the `AP:` line).
