### PR TITLE
HEADERNAME may not start with '-'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,23 @@ The Hanoi Omega-Automata Format
 
 This document describes the Hanoi Omega-Automata (HOA) format.  The name is a reference to the ATVA'13 conference, which was organized in Hanoi, and where the foundations of this format were laid.
 
-
-Current status
---------------
-
-This is version 1 of the format.  The [HTML](http://adl.github.io/hoaf/) and [PDF](http://adl.github.io/hoaf/hoaf.pdf) versions of this document are updated from [the sources on github](https://github.com/adl/hoaf/).
-If you see any problem, please [report it on the issue tracker](https://github.com/adl/hoaf/issues?state=open).
+The [HTML](http://adl.github.io/hoaf/) and [PDF](http://adl.github.io/hoaf/hoaf.pdf) versions of this document are updated from [the sources on github](https://github.com/adl/hoaf/).
 
 Current tool support is described on a [separate page](http://adl.github.io/hoaf/support.html).
 
 All the examples shown here can also be [downloaded separately](http://adl.github.io/hoaf/examples.html).
+
+Current status
+--------------
+
+This is version 1 of the format.  The document may evolve slightly to clarify some parts and fix typos, but you should expect no major semantic change.
+
+If you see any problem, please [report it on the issue tracker](https://github.com/adl/hoaf/issues?state=open).
+
+Change log:
+- 2015-02-24: Clarify that `HEADERNAME` may not start with `-`.
+- 2015-02-06: Version 1 published.
+
 
 Goals
 -----

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Common Tokens
 - `ANAME`: `@[0-9a-zA-Z_-]+`
   An alias name, i.e., "@" followed by some alphanumeric characters, `-` or `_`.  These are used to identify atomic propositions or subformulas.
 
-- `HEADERNAME`: `[a-zA-Z_-][0-9a-zA-Z_-]*:`
-  Header names are likes identifiers, except that they are immediately followed by a colon (i.e. no comment or space allowed).  If an `IDENTIFIER` is immediately followed by a colon, it should be considered as a `HEADERNAME`.
+- `HEADERNAME`: `[a-zA-Z_][0-9a-zA-Z_-]*:`
+  Header names are similar to identifiers, except that they are immediately followed by a colon (i.e. no comment or space allowed).  If an `IDENTIFIER` or a `BOOLEAN` is immediately followed by a colon, it should be considered as a `HEADERNAME`.
 
 General Layout
 --------------


### PR DESCRIPTION
Identifier may not start with `-`, so that `--ABORT--` may not be mistaken as an identifier.  And although we state that HEADERNAME are like identifiers followed by `:`, the given regex allows them to start with `-`.  This raises the question of whether `--ABORT--:` is a HEADERNAME, or if is `--ABORT--` followed by `:`.

I suggest we simply fix the HEADERNAME definition to disallow a leading `-`.  This is what is implemented in Spot 1.99a and jhoafparser 1.0.1 already.   (But maybe there is a development version of jhoafparser that recognizes `-:` as a HEADERNAME by now, because this is one case in the test-suite developed by Joachim.)
